### PR TITLE
WPG optional import 

### DIFF
--- a/tests/test_GaussianSourceCalculator.py
+++ b/tests/test_GaussianSourceCalculator.py
@@ -12,6 +12,5 @@ def test_run_default_parameters():
     print(type(data_out))
 
 
-def test_wrong_WPG_path(tmpdir):
-    with pytest.raises(ValueError):
-        GaussianSourceCalculator("gaussian_source")
+
+# test_wrong_WPG_path()

--- a/tests/test_GaussianSourceCalculator.py
+++ b/tests/test_GaussianSourceCalculator.py
@@ -2,18 +2,16 @@
 
 import pytest
 from SimExLite.SourceCalculators import GaussianSourceCalculator
-
-WPG_path = "/home/juncheng/GPFS/exfel/data/user/juncheng/WPG"
+from SimExLite.WavefrontData import WavefrontData
 
 
 def test_run_default_parameters():
-    calculator = GaussianSourceCalculator("gaussian_source", WPG_path)
+    calculator = GaussianSourceCalculator("gaussian_source")
     print(calculator.parameters)
     data_out = calculator.backengine()
     print(type(data_out))
 
 
 def test_wrong_WPG_path(tmpdir):
-    WPG_path_wrong = str(tmpdir / "xx")
     with pytest.raises(ValueError):
-        GaussianSourceCalculator("gaussian_source", WPG_path_wrong)
+        GaussianSourceCalculator("gaussian_source")


### PR DESCRIPTION
I removed the WPG_path parameter of GaussianSourceCalculator and moved the WPG imports to the beginning of the module, so all imports happen when the module is imported. As we discussed, it should be the user's responsibility to provide SimExLite with a working WPG module. 

The way it works now allows the user to import the module without WPG; in this case, a warning is emitted upon initializing `GaussianSourceCalculator`, and a `ModuleNotFoundError` is thrown when calling `backengine()`. If there's no use case of using the calculator without WPG, the first warning could be turned into an error, and then the second error becomes unneccessary.