### PR TITLE
New test cases for GaussianSourceCalculator

### DIFF
--- a/SimExLite/SourceCalculators/GaussianSourceCalculator.py
+++ b/SimExLite/SourceCalculators/GaussianSourceCalculator.py
@@ -195,7 +195,7 @@ class GaussianSourceCalculator(BaseCalculator):
 
 
 def get_divergence_from_beam_diameter(E, beam_diameter_fwhm):
-    """Calculate the divergence (radian) from and photon energy (eV) beam_diameter (m)"""
+    """Calculate the divergence (radian) from photon energy (eV) and beam_diameter (m)"""
     # The rms of the amplitude distribution (Gaussian)
     E = Quantity(E, Unit("eV"))
     beam_waist = beam_diameter_fwhm / np.sqrt(2.0 * np.log(2.0))

--- a/tests/test_GaussianSourceCalculator.py
+++ b/tests/test_GaussianSourceCalculator.py
@@ -139,7 +139,7 @@ def test_paths(tmp_path="tmp"):
     assert validate_result(gsc)
     assert os.path.exists(gsc.base_dir)
     assert os.path.exists(gsc.output_file_paths[0])
-    assert os.path.samefile(gsc.basedir, os.path.join(instr_dir, calc_dir))
+    assert os.path.samefile(gsc.base_dir, os.path.join(instr_dir, calc_dir))
     assert os.path.samefile(gsc.output_file_paths[0], os.path.join(instr_dir, calc_dir, outf))
 
 

--- a/tests/test_GaussianSourceCalculator.py
+++ b/tests/test_GaussianSourceCalculator.py
@@ -1,8 +1,11 @@
 """Test EMCPhoton"""
 
+import os
 import pytest
 from SimExLite.SourceCalculators import GaussianSourceCalculator
 from SimExLite.WavefrontData import WavefrontData
+
+import h5py
 
 
 def test_run_default_parameters():
@@ -12,5 +15,70 @@ def test_run_default_parameters():
     print(type(data_out))
 
 
+
+# more detailed testing needed:
+
+# test construction with and without default parameters
+def test_do_def_pms():
+    calculator = GaussianSourceCalculator(
+        name="test_gaussian",
+        input=None,
+        output_keys="Gaussian_wavefront",
+        output_filenames="test_wf.h5",
+        instrument_base_dir="./",
+        calculator_base_dir="GaussianSourceCalculator",
+        parameters=None,
+    )
+
+    print(GaussianSourceCalculator.get_divergence_from_beam_diameter(1000, 0.0001))
+
+
+def test_template():
+    gs = GaussianSourceCalculator(
+        name="GaussianTestSource",
+        input=None,
+        output_keys="Gaussian_wavefront",
+        output_data_types=WavefrontData,
+        output_filenames="wavefront.h5",
+        instrument_base_dir="./",
+        calculator_base_dir="GaussianSourceCalculator",
+        parameters=None,
+    )
+
+    gs.parameters
+
+
+def test_get_data():
+    gsc = GaussianSourceCalculator("gaussian_source")
+    gsc.backengine()
+    d = gsc.output.get_data()
+    print(d)
+
+
+def test_save(gnc, tmp_path):
+    gsc = GaussianSourceCalculator("gaussian_source")
+    gsc.backengine()
+    for f in gsc.output_file_paths:
+        assert h5py.is_hdf5(f) is True
+
+
+def test_dump_and_load(tmp_path='./'):
+    tmpf = os.path.join(tmp_path, 'dumptest.dump')
+    gsc = GaussianSourceCalculator("gaussian_source")
+    gsc.backengine()
+    gsc.dump(tmpf)
+    gsc2 = GaussianSourceCalculator('fromdump')
+    gsc2.from_dump(tmpf)
+    for key in gsc.parameters.parameters.keys():
+        assert gsc2.parameters['photon_energy'].value == gsc.parameters['photon_energy'].value
+
+
+
+
+# test each method
+# test a full construct-setup-run-collect workflow
+# test dump/load to/from disk
+
+test_get_data()
 
 # test_wrong_WPG_path()

--- a/tests/test_GaussianSourceCalculator.py
+++ b/tests/test_GaussianSourceCalculator.py
@@ -1,89 +1,189 @@
 """Test EMCPhoton"""
 
 import os
+import numpy as np
+from ocelot import spectrum
 import pytest
-from SimExLite.SourceCalculators import GaussianSourceCalculator
+from SimExLite.SourceCalculators.GaussianSourceCalculator import (
+    GaussianSourceCalculator,
+    get_divergence_from_beam_diameter,
+)
+from libpyvinyl import BaseCalculator, CalculatorParameters
+from libpyvinyl.BaseData import DataCollection
 from SimExLite.WavefrontData import WavefrontData
-
+from matplotlib import pyplot as plt
 import h5py
+from scipy.constants import hbar, c, electron_volt
 
 
-def test_run_default_parameters():
-    calculator = GaussianSourceCalculator("gaussian_source")
-    print(calculator.parameters)
-    data_out = calculator.backengine()
-    print(type(data_out))
+def validate_result(gsc):
+    """
+    Check the following on the output of GaussiannSourceCalculator:
+        - the output data is a DataCollection,
+        - nothing is none that should not be,
+        - limits make sense,
+        - the intensity is not zero everywhere and everytime.
+
+    This uses `get_data()`, so logically `test_get_data()` should be called before
+    any test using this.
+
+    Todo:
+        - More checks could be added.
+    """
+    d = gsc.output.get_data()
+    elf = d["electricField"]
+    xmax, xmin, ymax, ymin = [
+        d[which] for which in ["gridxMax", "gridxMin", "gridyMax", "gridyMin"]
+    ]
+    ints = np.abs(elf["x"]) ** 2 + np.abs(elf["y"]) ** 2
+    nothing_is_none = np.all([thing is not None for thing in [elf, xmax, xmin, ymax, ymin]])
+    lims_ok = xmax > xmin and ymax > ymin
+    data_ok = not np.all(ints == 0 + 0j)
+    return nothing_is_none and lims_ok and data_ok
 
 
-def test_run_default_parameters():
-    calculator = GaussianSourceCalculator("gaussian_source", WPG_path)
-    print(calculator.parameters)
-    data_out = calculator.backengine()
-    data_out.get_data()
+def test_divergence():
+    "test get_divergence_from_beam_diameter againist reference values"
+    test_evs = (1000, 2000, 2567, 1000 * np.pi)
+    test_diams = (1e-4, 2e-4, 1e-4 * np.sqrt(2))
+    pm_space = [(x, y) for x in test_evs for y in test_diams]  # cartesian product
+    res, ref = [], []
+    for ev, diam in pm_space:
+        res.append(get_divergence_from_beam_diameter(ev, diam))
+        w0 = diam / np.sqrt(2 * np.log(2))
+        e_joule = ev * electron_volt
+        ref.append(2 * hbar * c / (e_joule * w0))
 
-# more detailed testing needed:
+    assert np.allclose(res, ref, rtol=1e-8, atol=1e-8)
 
-# test construction with and without default parameters
-def test_do_def_pms():
-    calculator = GaussianSourceCalculator(
-        name="test_gaussian",
-        input=None,
-        output_keys="Gaussian_wavefront",
-        output_filenames="test_wf.h5",
-        instrument_base_dir="./",
-        calculator_base_dir="GaussianSourceCalculator",
-        parameters=None,
+
+def test_get_data(tmp_path="tmp"):
+    "test accessing to the results via output.get_data()"
+    os.makedirs(tmp_path, exist_ok=True)
+    gsc = GaussianSourceCalculator(
+        "gaussian_source", instrument_base_dir=tmp_path
     )
-
-    print(GaussianSourceCalculator.get_divergence_from_beam_diameter(1000, 0.0001))
-
-
-def test_template():
-    gs = GaussianSourceCalculator(
-        name="GaussianTestSource",
-        input=None,
-        output_keys="Gaussian_wavefront",
-        output_data_types=WavefrontData,
-        output_filenames="wavefront.h5",
-        instrument_base_dir="./",
-        calculator_base_dir="GaussianSourceCalculator",
-        parameters=None,
-    )
-
-    gs.parameters
-
-
-def test_get_data():
-    gsc = GaussianSourceCalculator("gaussian_source")
     gsc.backengine()
     d = gsc.output.get_data()
-    print(d)
+    elf = d["electricField"]
+    xmax, xmin, ymax, ymin = [
+        d[which] for which in ["gridxMax", "gridxMin", "gridyMax", "gridyMin"]
+    ]
+    assert np.all([data is not None for data in [elf, xmax, xmin, ymax, ymin]])
+    assert xmax > xmin and ymax > ymin
+
+    val = (np.abs(elf["x"]) ** 2 + np.abs(elf["y"]) ** 2).transpose((2, 0, 1))
+    i = len(val) // 2
+    plotdata = val[len(val) // 2]
+    fig, ax = plt.subplots()
+    ims = ax.imshow(plotdata, extent=(xmin, xmax, ymin, ymax))
+    plt.colorbar(ims)
+    plt.savefig(os.path.join(tmp_path, f"gsc_{i}.png"))
 
 
-def test_save(gnc, tmp_path):
-    gsc = GaussianSourceCalculator("gaussian_source")
+def test_run_default_parameters(tmp_path='tmp'):
+    "Test a simple execution of GSC with the default parameters."
+    gsc = GaussianSourceCalculator("gaussian_source", instrument_base_dir=tmp_path)
+    print(gsc.parameters)
+    data_out = gsc.backengine()
+    print(type(data_out))
+    assert validate_result(gsc)
+
+
+def test_custom_params(tmp_path='tmp'):
+    "Execute GSC with some uglier cusstom parameters."
+    gsc = GaussianSourceCalculator("gaussian_source", instrument_base_dir=tmp_path)
+
+    # set some "ugly" parameters
+    gsc.parameters["photon_energy"].value = 1e3 * np.pi + 0.6
+    gsc.parameters["photon_energy_relative_bandwidth"].value = 1e-3 * np.pi / 2
+    gsc.parameters["beam_diameter_fwhm"].value = 1e-4 / np.sqrt(2)
+    gsc.parameters["pulse_energy"].value = 2e-3 * 2.0 / 3
+    gsc.parameters["divergence"].value = get_divergence_from_beam_diameter(
+        1e3 * np.pi + 0.6, 1e-4 / np.sqrt(2)
+    )
+    gsc.parameters["photon_energy_spectrum_type"].value = "SASE"
+    gsc.parameters["number_of_transverse_grid_points"].value = 419
+    gsc.parameters["number_of_time_slices"].value = 103
+    gsc.parameters["z"].value = 29
+
+    print(gsc.parameters)
+    gsc.backengine()
+
+    assert validate_result(gsc)
+
+
+def test_spectrums(tmp_path='tmp'):
+    "Test the spectrum options with the default parameters."
+    gsc = GaussianSourceCalculator("gaussian_source", instrument_base_dir=tmp_path)
+    for spectrum in ["SASE", "tophat", "twocolour"]:
+        gsc.parameters["photon_energy_spectrum_type"].value = spectrum
+        gsc.backengine()
+        assert validate_result(gsc)
+
+
+def test_paths(tmp_path="tmp"):
+    "Check if passing custom paths works as excepted"
+    os.makedirs(tmp_path, exist_ok=True)
+    instr_dir = os.path.join(tmp_path, "gsc_path_test_instr")
+    calc_dir = "gsc_path_test_calc"
+    outf = "gsc_path_test.h5"
+    gsc = GaussianSourceCalculator(
+        "gaussian_source",
+        output_filenames=outf,
+        instrument_base_dir=instr_dir,
+        calculator_base_dir=calc_dir,
+    )
+    gsc.backengine()
+    print("output_files: ", gsc.output_file_paths, "\nbase_dir: ", gsc.base_dir)
+    assert validate_result(gsc)
+    assert os.path.exists(gsc.base_dir)
+    assert os.path.exists(gsc.output_file_paths[0])
+    assert os.path.samefile(gsc.basedir, os.path.join(instr_dir, calc_dir))
+    assert os.path.samefile(gsc.output_file_paths[0], os.path.join(instr_dir, calc_dir, outf))
+
+
+def test_save_data(tmp_path="tmp"):
+    "Check if the calculation produces a valid HDF5 file"
+    os.makedirs(tmp_path, exist_ok=True)
+    gsc = GaussianSourceCalculator("gaussian_source", instrument_base_dir=tmp_path)
     gsc.backengine()
     for f in gsc.output_file_paths:
-        assert h5py.is_hdf5(f) is True
+        print(f)
+        assert os.path.exists(f)
+        assert h5py.is_hdf5(f)
 
 
-def test_dump_and_load(tmp_path='./'):
-    tmpf = os.path.join(tmp_path, 'dumptest.dump')
-    gsc = GaussianSourceCalculator("gaussian_source")
-    gsc.backengine()
+def test_dump_and_load(tmp_path="tmp"):
+    "Check if dumping and loading an instrument works and leaves parameters unchanged."
+    os.makedirs(tmp_path, exist_ok=True)
+    tmpf = os.path.join(tmp_path, "dumptest.dump")
+    gsc = GaussianSourceCalculator("gaussian_source", instrument_base_dir=tmp_path)
+    # gsc.backengine()
     gsc.dump(tmpf)
-    gsc2 = GaussianSourceCalculator('fromdump')
+    gsc2 = GaussianSourceCalculator("fromdump")
     gsc2.from_dump(tmpf)
+    assert np.all(
+        [
+            gsc.output_filenames[i] == gsc2.output_filenames[i] for i in range(len(gsc.output_filenames))
+        ]
+    )
     for key in gsc.parameters.parameters.keys():
-        assert gsc2.parameters['photon_energy'].value == gsc.parameters['photon_energy'].value
+        assert gsc2.parameters[key].value == gsc.parameters[key].value
+    gsc2.backengine()
+    assert validate_result(gsc2)
 
 
+def main():
+    test_divergence()
+    test_get_data()
+    test_run_default_parameters()
+    test_custom_params()
+    test_spectrums()
+    test_dump_and_load()
+    test_paths()
+    test_save_data()
 
 
-# test each method
-# test a full construct-setup-run-collect workflow
-# test dump/load to/from disk
-
-test_get_data()
-
-# test_wrong_WPG_path()
+if __name__ == "__main__":
+    main()

--- a/tests/test_GaussianSourceCalculator.py
+++ b/tests/test_GaussianSourceCalculator.py
@@ -12,6 +12,5 @@ def test_run_default_parameters():
     print(type(data_out))
 
 
-def test_wrong_WPG_path(tmpdir):
-    with pytest.raises(ValueError):
-        GaussianSourceCalculator("gaussian_source")
+
+# test_wrong_WPG_path()

--- a/tests/test_GaussianSourceCalculator.py
+++ b/tests/test_GaussianSourceCalculator.py
@@ -2,18 +2,16 @@
 
 import pytest
 from SimExLite.SourceCalculators import GaussianSourceCalculator
-
-WPG_path = "/home/juncheng/GPFS/exfel/data/user/juncheng/WPG"
+from SimExLite.WavefrontData import WavefrontData
 
 
 def test_run_default_parameters():
-    calculator = GaussianSourceCalculator("gaussian_source", WPG_path)
+    calculator = GaussianSourceCalculator("gaussian_source")
     print(calculator.parameters)
     data_out = calculator.backengine()
     print(type(data_out))
 
 
 def test_wrong_WPG_path(tmpdir):
-    WPG_path_wrong = str(tmpdir / "xx")
     with pytest.raises(ValueError):
-        GaussianSourceCalculator("gaussian_source", WPG_path_wrong)
+        GaussianSourceCalculator("gaussian_source")


### PR DESCRIPTION
I added the following tests:

- Test the `get_divergence_from_beam_diameter` function and compare the result with a reference formula
- Test access to the results via output.get_data()
- Execute GSC with the default parameters
- Execute GSC with custom parameters
- Execute GSC with different spectrum options and the default parameters
- Test working with non-default paths
- Check if the calculation produces a valid HDF5 file
- Check if dumping and loading an instrument works and leaves parameters unchanged

Please tell me if there're other cases I should test for.